### PR TITLE
Fix Windows backslash errors and consolidate path warnings

### DIFF
--- a/plugins/productivity-suite/skills/note-taking/SKILL.md
+++ b/plugins/productivity-suite/skills/note-taking/SKILL.md
@@ -19,22 +19,18 @@ allowed-tools: Bash
 
 ## Script Invocation
 
-**CRITICAL:** Always use the tilde path `~/.claude/plugins/...` with forward slashes exactly as shown below. NEVER use Windows-style paths like `C:\Users\...` with backslashes - they will fail in bash.
+**CRITICAL Path Requirements:**
+- Use tilde `~/.claude/plugins/...` (expands on all platforms)
+- Use forward slashes `/` (works on Windows) - NEVER backslashes `\`
+- This exact pattern works from any directory on Windows, macOS, Linux
 
 ```bash
 echo "{\"command\":\"<cmd>\",\"param\":\"value\"}" | python ~/.claude/plugins/marketplaces/productivity-skills/plugins/productivity-suite/skills/note-taking/scripts/notes_manager.py
 ```
 
-**Path notes:**
-- Use full path (skill can be invoked from any working directory)
-- Tilde (~) expands to user home on all platforms (Windows: `C:\Users\username\`, macOS/Linux: `/home/username/`)
-- Path shown is for standard marketplace installation; adjust if installed manually
-
 **Cross-platform notes:**
 - Use `python` (not `python3`) - works on Windows, macOS, Linux
 - Use double quotes with escaped inner quotes: `echo "{\"command\":\"...\"}"` (works on all platforms)
-- **ALWAYS use forward slashes** in the path (Python accepts them on Windows) - NEVER use backslashes
-- The tilde `~` is properly expanded by bash on all platforms - use it instead of absolute paths
 - Script auto-detects notes directory (OneDrive on Windows, Documents otherwise, or `$NOTES_DIR` if set)
 
 ## API Commands


### PR DESCRIPTION
## Summary

Fixes issue where Claude was using Windows-style backslashes in bash commands, causing script invocation failures. Preserves the working fix in git history, then applies consolidation to maintain lean SKILL.md structure.

## Issue

Claude Code sessions were sometimes generating commands like:
```bash
python C:\Users\...\notes_manager.py
```

This fails in bash because backslashes are escape characters. The tilde path with forward slashes is required:
```bash
python ~/.claude/plugins/.../notes_manager.py
```

## Changes

### Commit 1: Add critical warning (f132449)
- Added explicit CRITICAL warning at top of Script Invocation section
- Emphasized forward slash requirement in cross-platform notes
- Added note about tilde expansion
- **Purpose:** Preserve the working fix that addresses immediate failure mode

### Commit 2: Consolidate warnings (3e7d646)
- Consolidated path requirements into single "CRITICAL Path Requirements" block
- Removed duplicate information between warning and cross-platform notes
- More scannable bullet format
- **Purpose:** Maintain lean structure while keeping effectiveness

## Result

**Before (145 lines):**
- No explicit warning about Windows backslashes
- Path information scattered across multiple notes

**After Commit 1 (149 lines):**
- ✅ Prevents Windows backslash errors
- ⚠️ Some redundancy between sections

**After Commit 2 (144 lines):**
- ✅ Prevents Windows backslash errors
- ✅ No redundancy
- ✅ More scannable format
- ✅ Net improvement from original (145 → 144 lines)

## Testing

✅ Tested by user - commands now work correctly
✅ Maintains refactoring goals (lean, under 200 lines)
✅ No duplication or redundancy

## Breaking Changes

None. This is a documentation clarification only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)