### PR TITLE
fix: add plugin.json for skill registration

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,6 @@
     {
       "name": "productivity-suite",
       "description": "Complete productivity suite including AI-navigable note-taking, task management, and knowledge capture. Transform markdown notes into a searchable second brain.",
-      "version": "1.0.0",
       "author": {
         "name": "Tony McDow",
         "url": "https://github.com/mcdow-webworks"
@@ -19,10 +18,7 @@
       "source": "./plugins/productivity-suite",
       "category": "productivity",
       "tags": ["notes", "productivity", "knowledge-management", "markdown", "second-brain", "task-management"],
-      "strict": false,
-      "skills": [
-        "./skills/note-taking"
-      ]
+      "strict": false
     }
   ]
 }

--- a/plugins/productivity-suite/.claude-plugin/plugin.json
+++ b/plugins/productivity-suite/.claude-plugin/plugin.json
@@ -1,0 +1,21 @@
+{
+  "name": "productivity-suite",
+  "version": "1.0.0",
+  "description": "Complete productivity suite including AI-navigable note-taking, task management, and knowledge capture. Transform markdown notes into a searchable second brain.",
+  "author": {
+    "name": "Tony McDow",
+    "email": "mcdow@webworks.com",
+    "url": "https://github.com/mcdow-webworks"
+  },
+  "homepage": "https://github.com/mcdow-webworks/productivity-skills",
+  "repository": "https://github.com/mcdow-webworks/productivity-skills",
+  "license": "MIT",
+  "keywords": [
+    "notes",
+    "productivity",
+    "knowledge-management",
+    "markdown",
+    "second-brain",
+    "task-management"
+  ]
+}


### PR DESCRIPTION
## Summary

Fixes the note-taking skill not being registered with Claude Code's Skill tool. This is the same issue that was fixed in webworks-claude-skills (PR #26).

**Root cause:** `plugin.json` was missing entirely. Claude Code requires it at `plugins/<name>/.claude-plugin/plugin.json` for skill auto-discovery.

## Changes

- **Add** `plugins/productivity-suite/.claude-plugin/plugin.json` with proper schema
- **Remove** redundant `version` field from marketplace.json plugin definition
- **Remove** redundant `skills` array from marketplace.json (skills are auto-discovered)

## New Structure

```
plugins/productivity-suite/
├── .claude-plugin/
│   └── plugin.json          ← NEW
└── skills/
    └── note-taking/
        └── SKILL.md
```

## Test Plan

After merge:
- [ ] Clear plugin cache (delete `~/.claude/plugins/cache/productivity-skills`)
- [ ] Restart Claude Code
- [ ] Verify skill is invokable: `productivity-suite:note-taking`

Generated with [Claude Code](https://claude.com/claude-code)