### PR TITLE
Fix #16: Test: Run bash commands and log output to test-to-delete

### DIFF
--- a/test-to-delete
+++ b/test-to-delete
@@ -1,0 +1,27 @@
+$ uname -a
+MINGW64_NT-10.0-19045 Trantor 3.6.3-7674c51e.x86_64 2025-07-01 09:13 UTC x86_64 Msys
+
+$ pwd
+/c/Users/mcdow/AppData/Local/claude-docker-worker/workdir/repos/mcdow-webworks-productivity-skills
+
+$ ls -la
+.claude-plugin/
+.github/
+docs/
+plans/
+plugins/
+scripts/
+.gitignore  704B
+CLAUDE.md  17.0K
+LICENSE  1.1K
+note-taking-skill.zip  8.4K
+README.md  9.2K
+requirements-qn.txt  113B
+
+6 files, 6 dirs (2(no ext) 2.md 1.zip 1.txt)
+
+$ git --version
+git version 2.50.1.windows.1
+
+$ echo "Hello from Claude Dockworker"
+Hello from Claude Dockworker

--- a/test-to-delete
+++ b/test-to-delete
@@ -25,3 +25,16 @@ git version 2.50.1.windows.1
 
 $ echo "Hello from Claude Dockworker"
 Hello from Claude Dockworker
+
+$ WebWorks.AutoMap.exe --version
+WebWorks ePublisher AutoMap 2025.1.4651.0
+
+error:  unknown option specified (--version)
+No job or project file specified
+
+License key refresh not required.  Existing keys are valid.
+Usage:  WebWorks.Automap.exe [-f|--nonotify] [-s|--stagingdir directory]
+        [-t|--target target1,target2] [-n|--nodeploy] [-u|--update]
+        [-j|--justupdate] [-d|--deployfolder directory] [-c|--clean]
+        [-l|--cleandeploy] [--skip-reports] [-?|--help] [--usage]
+        ePublisher project or Automap job file


### PR DESCRIPTION
Addresses #16

Done. Here's the PR description:

---

## Summary

Smoke test for the Claude Dockworker pipeline per #16.

- Ran 5 basic bash commands (`uname -a`, `pwd`, `ls -la`, `git --version`, `echo`)
- Created `test-to-delete` in the repo root with each command and its output logged in the requested format

## Files Changed

- **`test-to-delete`** (new) — Command log output file

## Cleanup

This file and PR can be deleted after verifying the worker pipeline works correctly.

— 🚢 McDow Claude Worker