### PR TITLE
Fix #16: Test: Run bash commands and log output to test-to-delete

### DIFF
--- a/test-to-delete
+++ b/test-to-delete
@@ -1,0 +1,29 @@
+$ uname -a
+MINGW64_NT-10.0-19045 Trantor 3.6.3-7674c51e.x86_64 2025-07-01 09:13 UTC x86_64 Msys
+
+$ pwd
+/c/Users/mcdow/AppData/Local/claude-docker-worker/workdir/repos/mcdow-webworks-productivity-skills
+
+$ ls -la
+total 45
+drwxr-xr-x 1 mcdow 197609     0 Jul  6 19:44 .
+drwxr-xr-x 1 mcdow 197609     0 Jul  6 19:44 ..
+drwxr-xr-x 1 mcdow 197609     0 Jul  6 19:44 .claude-plugin
+drwxr-xr-x 1 mcdow 197609     0 Jul  6 19:44 .git
+drwxr-xr-x 1 mcdow 197609     0 Jul  6 19:44 .github
+-rw-r--r-- 1 mcdow 197609   704 Jul  6 19:44 .gitignore
+-rw-r--r-- 1 mcdow 197609 17008 Jul  6 19:44 CLAUDE.md
+-rw-r--r-- 1 mcdow 197609  1089 Jul  6 19:44 LICENSE
+-rw-r--r-- 1 mcdow 197609  9239 Jul  6 19:44 README.md
+drwxr-xr-x 1 mcdow 197609     0 Jul  6 19:44 docs
+-rw-r--r-- 1 mcdow 197609  8411 Jul  6 19:44 note-taking-skill.zip
+drwxr-xr-x 1 mcdow 197609     0 Jul  6 19:44 plans
+drwxr-xr-x 1 mcdow 197609     0 Jul  6 19:44 plugins
+-rw-r--r-- 1 mcdow 197609   113 Jul  6 19:44 requirements-qn.txt
+drwxr-xr-x 1 mcdow 197609     0 Jul  6 19:44 scripts
+
+$ git --version
+git version 2.50.1.windows.1
+
+$ echo "Hello from Claude Dockworker"
+Hello from Claude Dockworker


### PR DESCRIPTION
Addresses #16

Done. Here's the PR description:

---

## Summary

Smoke test for the Claude Dockworker pipeline. Ran the five requested bash commands and logged their output to `test-to-delete` in the repo root.

**Commands executed:**
- `uname -a` — confirms MINGW64 environment on Windows 10
- `pwd` — confirms working directory
- `ls -la` — lists repo contents
- `git --version` — git 2.50.1
- `echo "Hello from Claude Dockworker"` — basic echo test

**Files changed:**
- `test-to-delete` (new) — command log file

This file and PR can be deleted after verification, as noted in the issue.

— 🚢 McDow Claude Worker