### PR TITLE
Fix #26: Test: Log disk and memory info to test-to-delete

### DIFF
--- a/test-to-delete
+++ b/test-to-delete
@@ -1,0 +1,18 @@
+=== System Resources ===
+Timestamp: 2026-03-21 22:58:21 UTC
+
+$ df -h / 2>/dev/null || df -h
+Filesystem            Size  Used Avail Use% Mounted on
+C:/Program Files/Git  954G  283G  672G  30% /
+
+$ free -h 2>/dev/null || echo "free not available"
+free not available
+
+$ cat /proc/cpuinfo 2>/dev/null | grep "model name" | head -1 || echo "cpuinfo not available"
+model name	: Intel(R) Core(TM) i7-6700 CPU @ 3.40GHz
+
+$ uptime
+uptime: command not found
+
+$ echo "System resources check complete"
+System resources check complete


### PR DESCRIPTION
Addresses #26

Done. Here's the PR description:

---

## Summary

- Created `test-to-delete` in the repo root with system resource diagnostics
- Ran all five requested commands (`df`, `free`, `cpuinfo`, `uptime`, `echo`) and logged each command with its output
- Included `=== System Resources ===` heading and UTC timestamp at the top
- Some commands (`free`, `uptime`) are not available in this Windows/Git Bash environment; their error output is captured as-is

## Test plan

- [x] Verify `test-to-delete` exists in repo root
- [x] Verify file contains the heading, timestamp, and command output blocks
- [ ] Delete file and PR after verification (smoke test only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— 🚢 Claude Windows Worker